### PR TITLE
Initializing Payload

### DIFF
--- a/main.js
+++ b/main.js
@@ -393,6 +393,7 @@ var QueryBuilder = (function(){
 		if(this.parent.settings.flags.useXML === true){
 			this.payload = builder.buildObject(this.options);
 		}else{
+			this.payload = '';
 			for(var arg in this.options){
 				this.payload += '&' + arg + '=' + this.options[arg];
 			}


### PR DESCRIPTION
Problem: Crashing when building the Payload for GET calls.
Fix: Initializing the Payload, initially is undefined.