### PR TITLE
Rate Limit additional handling

### DIFF
--- a/src/quickbase.ts
+++ b/src/quickbase.ts
@@ -210,7 +210,6 @@ export class QuickBase {
 				}
 				
 				if (err.response.status === 429 && this.settings.retryOnQuotaExceeded) {
-				    console.log("Rate Limit reached - reattempting in " + debugData['x-ratelimit-reset'] + " milliseconds.");
 				    await new Promise(resolve => setTimeout(resolve, debugData['x-ratelimit-reset']));
 				    return this.request(actOptions, reqOptions, passThrough);
 				}


### PR DESCRIPTION
We have an app with many concurrent connections. On occasion the calls hit the API rate limit and throw an error. It would be nice to handle this at the library level, rather than handling it throughout the app.