### PR TITLE
Updated package.json to reflect that deepmerge is a prod dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "quickbase",
-      "version": "5.0.16",
+      "version": "5.0.20",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "dependencies": {
     "axios": "^0.27.2",
     "debug": "^4.3.4",
-    "generic-throttle": "^3.1.0"
+    "generic-throttle": "^3.1.0",
+    "deepmerge": "^4.2.2"
   },
   "devDependencies": {
     "@ava/typescript": "^3.0.1",
@@ -49,7 +50,6 @@
     "@types/node": "^18.7.18",
     "ava": "^4.3.3",
     "browserify": "^17.0.0",
-    "deepmerge": "^4.2.2",
     "dotenv": "^16.0.2",
     "minify": "7.2.2",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
"deepmerge" was listed as a dev dependency, but it is needed in the fully built code. I have updated the package.json to include it as a regular dependency.

I found this while trying to load the module in Deno. Importing the module after a clean `npm i --omit=dev` produces a **MODULE_NOT_FOUND** error in node, and a similar error in Deno.

Example code (for both Node and Deno):
```javascript
import { createRequire } from "node:module";

const require = createRequire(import.meta.url);
const { QuickBase } = require("./node-quickbase/dist/quickbase.js");

const userToken = "xx_yy_zzz";

const main = async () => {

    const qb = new QuickBase({
        userToken,
        realm: "xxx.quickbase.com",
    });

    const result = await qb.getApp({
        appId: "abcdefg"
    });

    console.log(result);
}

main();
```